### PR TITLE
Improve CLI language and cancelability

### DIFF
--- a/actions/groupModuleLimit.js
+++ b/actions/groupModuleLimit.js
@@ -1,11 +1,12 @@
 import inquirer from "inquirer";
 import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
+import { promptFields, promptField, CANCEL } from "../prompt.js";
 
 export const handleGroupModuleLimit = async () => {
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
-    message: "Действие:",
+    message: "Action:",
     choices: ["GET all", "GET by id", "POST", "PUT", "DELETE"],
   });
 
@@ -14,55 +15,74 @@ export const handleGroupModuleLimit = async () => {
   }
 
   if (action === "GET by id") {
-    const { id } = await inquirer.prompt({ name: "id", message: "ID:" });
+    const id = await promptField({ name: "id", message: "ID:" });
+    if (id === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     console.log(await apiGet(`/api/group-module-limits/${id}`));
   }
 
   if (action === "POST") {
-    const fields = await inquirer.prompt([
+    const fields = await promptFields([
       {
         name: "GroupCode",
         message: "GroupCode:",
-        validate: (v) => v.trim() !== "" || "Обязательное поле",
+        validate: (v) => v.trim() !== "" || "Required field",
       },
       {
         name: "Module",
         message: "Module:",
-        validate: (v) => v.trim() !== "" || "Обязательное поле",
+        validate: (v) => v.trim() !== "" || "Required field",
       },
       {
         name: "Hour",
         message: "Hour:",
-        validate: (v) => !isNaN(v) || "Введите число",
+        validate: (v) => !isNaN(v) || "Enter a number",
       },
       {
         name: "MaxLicenses",
         message: "MaxLicenses:",
-        validate: (v) => !isNaN(v) || "Введите число",
+        validate: (v) => !isNaN(v) || "Enter a number",
       },
     ]);
-    console.log("Отправляем данные:", fields);
+    if (fields === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     console.log(await apiPost("/api/group-module-limits", fields));
   }
 
   if (action === "PUT") {
-    const { id } = await inquirer.prompt({ name: "id", message: "ID:" });
-    const fields = await inquirer.prompt([
+    const id = await promptField({ name: "id", message: "ID:" });
+    if (id === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    const fields = await promptFields([
       { name: "GroupCode", message: "GroupCode:" },
       { name: "Module", message: "Module:" },
-      { name: "Hour", message: "Hour:", validate: (v) => !isNaN(v) },
+      { name: "Hour", message: "Hour:", validate: (v) => !isNaN(v) || "Enter a number" },
       {
         name: "MaxLicenses",
         message: "MaxLicenses:",
-        validate: (v) => !isNaN(v),
+        validate: (v) => !isNaN(v) || "Enter a number",
       },
     ]);
+    if (fields === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     console.log(await apiPut(`/api/group-module-limits/${id}`, fields));
   }
 
   if (action === "DELETE") {
-    const { id } = await inquirer.prompt({ name: "id", message: "ID:" });
+    const id = await promptField({ name: "id", message: "ID:" });
+    if (id === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     await apiDelete(`/api/group-module-limits/${id}`);
-    console.log("Удалено");
+    console.log("Deleted");
   }
 };

--- a/actions/limit.js
+++ b/actions/limit.js
@@ -1,16 +1,21 @@
 import inquirer from "inquirer";
 import { apiGet, apiPost } from "../api.js";
+import { promptField, CANCEL } from "../prompt.js";
 
 export const handleLimits = async () => {
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
-    message: "Действие:",
+    message: "Action:",
     choices: ["GET check/{pc}", "GET users", "POST stop session"],
   });
 
   if (action === "GET check/{pc}") {
-    const { pc } = await inquirer.prompt({ name: "pc", message: "PC:" });
+    const pc = await promptField({ name: "pc", message: "PC:" });
+    if (pc === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     const result = await apiGet(`/api/limits/check/${pc}`);
     console.log("Code:", result);
   }
@@ -20,10 +25,11 @@ export const handleLimits = async () => {
   }
 
   if (action === "POST stop session") {
-    const { user } = await inquirer.prompt({
-      name: "user",
-      message: "User login:",
-    });
+    const user = await promptField({ name: "user", message: "User login:" });
+    if (user === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     const result = await apiPost(`/api/limits/users/session/stop/${user}`, {});
     console.log(result);
   }

--- a/actions/userGroup.js
+++ b/actions/userGroup.js
@@ -1,11 +1,12 @@
 import inquirer from "inquirer";
 import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
+import { promptFields, promptField, CANCEL } from "../prompt.js";
 
 export const handleUserGroup = async () => {
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
-    message: "Действие:",
+    message: "Action:",
     choices: ["GET all", "GET by UserName", "POST", "PUT", "DELETE"],
   });
 
@@ -14,31 +15,51 @@ export const handleUserGroup = async () => {
   }
 
   if (action === "GET by UserName") {
-    const { userName } = await inquirer.prompt({ name: "userName", message: "UserName:" });
+    const userName = await promptField({ name: "userName", message: "UserName:" });
+    if (userName === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     console.log(await apiGet(`/api/user-groups/${userName}`));
   }
 
   if (action === "POST") {
-    const fields = await inquirer.prompt([
-      { name: "UserName", message: "Введите UserName:" },
-      { name: "Group", message: "Введите Group:" },
-      { name: "WindowsUser", message: "Введите WindowsUser:" },
+    const fields = await promptFields([
+      { name: "UserName", message: "UserName:" },
+      { name: "Group", message: "Group:" },
+      { name: "WindowsUser", message: "WindowsUser:" },
     ]);
+    if (fields === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     console.log(await apiPost("/api/user-groups", fields));
   }
 
   if (action === "PUT") {
-    const { userName } = await inquirer.prompt({ name: "userName", message: "UserName для обновления:" });
-    const fields = await inquirer.prompt([
-      { name: "Group", message: "Введите Group:" },
-      { name: "WindowsUser", message: "Введите WindowsUser:" },
+    const userName = await promptField({ name: "userName", message: "UserName to update:" });
+    if (userName === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    const fields = await promptFields([
+      { name: "Group", message: "Group:" },
+      { name: "WindowsUser", message: "WindowsUser:" },
     ]);
+    if (fields === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     console.log(await apiPut(`/api/user-groups/${userName}`, fields));
   }
 
   if (action === "DELETE") {
-    const { userName } = await inquirer.prompt({ name: "userName", message: "UserName для удаления:" });
+    const userName = await promptField({ name: "userName", message: "UserName to delete:" });
+    if (userName === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
     await apiDelete(`/api/user-groups/${userName}`);
-    console.log("Удалено");
+    console.log("Deleted");
   }
 };

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const resources = [
   { name: 'User Group', value: 'user-group' },
   { name: 'Limits', value: 'limits' },
   new inquirer.Separator(),
-  { name: 'Выход', value: 'exit' }
+  { name: 'Exit', value: 'exit' }
 ];
 
 const handlers = {
@@ -24,12 +24,12 @@ const main = async () => {
     const { resource } = await inquirer.prompt({
       type: 'list',
       name: 'resource',
-      message: 'Выбери ресурс:',
+      message: 'Select resource:',
       choices: resources
     });
 
     if (resource === 'exit') {
-      console.log('Завершено.');
+      console.log('Completed.');
       process.exit(0);
     }
 

--- a/prompt.js
+++ b/prompt.js
@@ -1,0 +1,33 @@
+import inquirer from 'inquirer';
+
+export const CANCEL = Symbol('cancel');
+
+export async function promptField({ name, message, validate }) {
+  const answer = await inquirer.prompt({
+    name,
+    message: `${message} (type "cancel" to abort)`,
+    validate: (v) => {
+      if (typeof v === 'string' && v.trim().toLowerCase() === 'cancel') {
+        return true;
+      }
+      return validate ? validate(v) : true;
+    }
+  });
+  const value = answer[name];
+  if (typeof value === 'string' && value.trim().toLowerCase() === 'cancel') {
+    return CANCEL;
+  }
+  return value;
+}
+
+export async function promptFields(fields) {
+  const result = {};
+  for (const field of fields) {
+    const value = await promptField(field);
+    if (value === CANCEL) {
+      return CANCEL;
+    }
+    result[field.name] = value;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- change console messages to English
- add a prompt helper to support typing "cancel" to abort
- use the helper across resource actions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b05d82c3c8320b38f606b4a071f7b