### PR TITLE
Add colors for HTTP methods

### DIFF
--- a/actions/groupModuleLimit.js
+++ b/actions/groupModuleLimit.js
@@ -1,4 +1,5 @@
 import inquirer from "inquirer";
+import chalk from "chalk";
 import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
 import { promptFields, promptField, CANCEL } from "../prompt.js";
 
@@ -7,7 +8,13 @@ export const handleGroupModuleLimit = async () => {
     type: "list",
     name: "action",
     message: "Action:",
-    choices: ["GET all", "GET by id", "POST", "PUT", "DELETE"],
+    choices: [
+      `${chalk.green('GET')} all`,
+      `${chalk.green('GET')} by id`,
+      chalk.keyword('orange')('POST'),
+      chalk.yellow('PUT'),
+      chalk.red('DELETE')
+    ],
   });
 
   if (action === "GET all") {

--- a/actions/limit.js
+++ b/actions/limit.js
@@ -1,4 +1,5 @@
 import inquirer from "inquirer";
+import chalk from "chalk";
 import { apiGet, apiPost } from "../api.js";
 import { promptField, CANCEL } from "../prompt.js";
 
@@ -7,7 +8,11 @@ export const handleLimits = async () => {
     type: "list",
     name: "action",
     message: "Action:",
-    choices: ["GET check/{pc}", "GET users", "POST stop session"],
+    choices: [
+      `${chalk.green('GET')} check/{pc}`,
+      `${chalk.green('GET')} users`,
+      `${chalk.keyword('orange')('POST')} stop session`
+    ],
   });
 
   if (action === "GET check/{pc}") {

--- a/actions/userGroup.js
+++ b/actions/userGroup.js
@@ -1,4 +1,5 @@
 import inquirer from "inquirer";
+import chalk from "chalk";
 import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
 import { promptFields, promptField, CANCEL } from "../prompt.js";
 
@@ -7,7 +8,13 @@ export const handleUserGroup = async () => {
     type: "list",
     name: "action",
     message: "Action:",
-    choices: ["GET all", "GET by UserName", "POST", "PUT", "DELETE"],
+    choices: [
+      `${chalk.green('GET')} all`,
+      `${chalk.green('GET')} by UserName`,
+      chalk.keyword('orange')('POST'),
+      chalk.yellow('PUT'),
+      chalk.red('DELETE')
+    ],
   });
 
   if (action === "GET all") {

--- a/api.js
+++ b/api.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import dotenv from 'dotenv';
 import os from 'os';
 import path from 'path';
+import chalk from 'chalk';
 
 dotenv.config({ path: path.join(os.homedir(), '.slim-cli', '.env') });
 const api = axios.create({
@@ -9,7 +10,22 @@ const api = axios.create({
   headers: { 'X-API-Key': process.env.X_API_KEY }
 });
 
-export const apiGet = async url => (await api.get(url)).data;
-export const apiPost = async (url, data) => (await api.post(url, data)).data;
-export const apiPut = async (url, data) => (await api.put(url, data)).data;
-export const apiDelete = async url => (await api.delete(url)).data;
+export const apiGet = async url => {
+  console.log(chalk.green('GET'), url);
+  return (await api.get(url)).data;
+};
+
+export const apiPost = async (url, data) => {
+  console.log(chalk.keyword('orange')('POST'), url);
+  return (await api.post(url, data)).data;
+};
+
+export const apiPut = async (url, data) => {
+  console.log(chalk.yellow('PUT'), url);
+  return (await api.put(url, data)).data;
+};
+
+export const apiDelete = async url => {
+  console.log(chalk.red('DELETE'), url);
+  return (await api.delete(url)).data;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.11.0",
+        "chalk": "^5.4.1",
         "dotenv": "^17.2.1",
         "inquirer": "^12.9.0"
+      },
+      "bin": {
+        "slim-cli": "index.js"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -385,6 +389,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chardet": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "type": "module",
-    "bin": {
+  "bin": {
     "slim-cli": "index.js"
   },
   "scripts": {
@@ -16,6 +16,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.11.0",
+    "chalk": "^5.4.1",
     "dotenv": "^17.2.1",
     "inquirer": "^12.9.0"
   }


### PR DESCRIPTION
## Summary
- include `chalk` dependency
- colorize menu options in `actions`
- log HTTP method and URL with colors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b0b70863083208969dc46a7aeda0c