### PR TITLE
Add configurable global CLI setup

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,31 +1,35 @@
 import axios from 'axios';
-import dotenv from 'dotenv';
-import os from 'os';
-import path from 'path';
 import chalk from 'chalk';
+import { getConfig } from './config.js';
 
-dotenv.config({ path: path.join(os.homedir(), '.slim-cli', '.env') });
-const api = axios.create({
-  baseURL: process.env.BASE_URL,
-  headers: { 'X-API-Key': process.env.X_API_KEY }
-});
+const createApi = () => {
+  const { BASE_URL, X_API_KEY } = getConfig();
+  return axios.create({
+    baseURL: BASE_URL,
+    headers: { 'X-API-Key': X_API_KEY }
+  });
+};
 
 export const apiGet = async url => {
+  const api = createApi();
   console.log(chalk.green('GET'), url);
   return (await api.get(url)).data;
 };
 
 export const apiPost = async (url, data) => {
+  const api = createApi();
   console.log(chalk.keyword('orange')('POST'), url);
   return (await api.post(url, data)).data;
 };
 
 export const apiPut = async (url, data) => {
+  const api = createApi();
   console.log(chalk.yellow('PUT'), url);
   return (await api.put(url, data)).data;
 };
 
 export const apiDelete = async url => {
+  const api = createApi();
   console.log(chalk.red('DELETE'), url);
   return (await api.delete(url)).data;
 };

--- a/config.js
+++ b/config.js
@@ -1,0 +1,18 @@
+import Conf from 'conf';
+import inquirer from 'inquirer';
+
+const store = new Conf({projectName: 'slim-cli'});
+
+export const getConfig = () => ({
+  BASE_URL: store.get('BASE_URL'),
+  X_API_KEY: store.get('X_API_KEY')
+});
+
+export const configure = async () => {
+  const answers = await inquirer.prompt([
+    {name: 'BASE_URL', message: 'BASE_URL:', default: store.get('BASE_URL') || ''},
+    {name: 'X_API_KEY', message: 'X_API_KEY:', default: store.get('X_API_KEY') || ''}
+  ]);
+  store.set(answers);
+  console.log('Configuration saved at', store.path);
+};

--- a/index.js
+++ b/index.js
@@ -4,11 +4,13 @@ import inquirer from 'inquirer';
 import { handleGroupModuleLimit } from './actions/groupModuleLimit.js';
 import { handleUserGroup } from './actions/userGroup.js';
 import { handleLimits } from './actions/limit.js';
+import { configure } from './config.js';
 
 const resources = [
   { name: 'Group Module Limit', value: 'group-module-limit' },
   { name: 'User Group', value: 'user-group' },
   { name: 'Limits', value: 'limits' },
+  { name: 'Configure', value: 'configure' },
   new inquirer.Separator(),
   { name: 'Exit', value: 'exit' }
 ];
@@ -16,10 +18,15 @@ const resources = [
 const handlers = {
   'group-module-limit': handleGroupModuleLimit,
   'user-group': handleUserGroup,
-  'limits': handleLimits
+  'limits': handleLimits,
+  'configure': configure
 };
 
 const main = async () => {
+  if (process.argv[2] === 'config') {
+    await configure();
+    return;
+  }
   while (true) {
     const { resource } = await inquirer.prompt({
       type: 'list',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "axios": "^1.11.0",
     "chalk": "^5.4.1",
-    "dotenv": "^17.2.1",
+    "conf": "^14.0.0",
     "inquirer": "^12.9.0"
   }
 }


### PR DESCRIPTION
## Summary
- allow storing `BASE_URL` and `X_API_KEY` using `conf`
- add interactive `config` command
- refactor API creation to read from config

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688b11924dac83208bc037d7b2fcdf8a