### PR TITLE
Add schedule retrieval command

### DIFF
--- a/actions/schedule.js
+++ b/actions/schedule.js
@@ -1,0 +1,30 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+import { apiGet } from "../api.js";
+import { promptField, CANCEL } from "../prompt.js";
+
+export const handleSchedule = async () => {
+  const { action } = await inquirer.prompt({
+    type: "list",
+    name: "action",
+    message: "Action:",
+    choices: [
+      { name: `${chalk.green("GET")}` + " by user", value: "GET by user" },
+      new inquirer.Separator(),
+      { name: "Back", value: "back" },
+    ],
+  });
+
+  if (action === "back") {
+    return;
+  }
+
+  if (action === "GET by user") {
+    const userName = await promptField({ name: "userName", message: "UserName:" });
+    if (userName === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    console.log(await apiGet(`/api/schedule/${userName}`));
+  }
+};

--- a/index.js
+++ b/index.js
@@ -4,12 +4,14 @@ import inquirer from 'inquirer';
 import { handleGroupModuleLimit } from './actions/groupModuleLimit.js';
 import { handleUserGroup } from './actions/userGroup.js';
 import { handleLimits } from './actions/limit.js';
+import { handleSchedule } from './actions/schedule.js';
 import { configure } from './config.js';
 
 const resources = [
   { name: 'Group Module Limit', value: 'group-module-limit' },
   { name: 'User Group', value: 'user-group' },
   { name: 'Limits', value: 'limits' },
+  { name: 'Schedule', value: 'schedule' },
   { name: 'Configure', value: 'configure' },
   new inquirer.Separator(),
   { name: 'Exit', value: 'exit' }
@@ -19,6 +21,7 @@ const handlers = {
   'group-module-limit': handleGroupModuleLimit,
   'user-group': handleUserGroup,
   'limits': handleLimits,
+  'schedule': handleSchedule,
   'configure': configure
 };
 


### PR DESCRIPTION
## Summary
- support retrieving user schedule via CLI

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688c85fe8c248320a1eb465bfc69430b