### PR TITLE
feat: add exception user CLI

### DIFF
--- a/actions/exceptionUser.js
+++ b/actions/exceptionUser.js
@@ -1,0 +1,79 @@
+import inquirer from "inquirer";
+import chalk from "chalk";
+import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
+import { promptFields, promptField, CANCEL } from "../prompt.js";
+
+export const handleExceptionUser = async () => {
+  const { action } = await inquirer.prompt({
+    type: "list",
+    name: "action",
+    message: "Action:",
+    choices: [
+      { name: `${chalk.green("GET")} all`, value: "GET all" },
+      { name: `${chalk.green("GET")} by id`, value: "GET by id" },
+      { name: chalk.hex("#ff8800ff")("POST"), value: "POST" },
+      { name: chalk.yellow("PUT"), value: "PUT" },
+      { name: chalk.red("DELETE"), value: "DELETE" },
+      new inquirer.Separator(),
+      { name: "Back", value: "back" }
+    ]
+  });
+
+  if (action === "back") {
+    return;
+  }
+
+  if (action === "GET all") {
+    console.table(await apiGet("/api/exception-users"));
+  }
+
+  if (action === "GET by id") {
+    const id = await promptField({ name: "id", message: "ID:" });
+    if (id === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    console.log(await apiGet(`/api/exception-users/${id}`));
+  }
+
+  if (action === "POST") {
+    const fields = await promptFields([
+      {
+        name: "UserName",
+        message: "UserName:",
+        validate: (v) => v.trim() !== "" || "Required field"
+      }
+    ]);
+    if (fields === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    console.log(await apiPost("/api/exception-users", fields));
+  }
+
+  if (action === "PUT") {
+    const id = await promptField({ name: "id", message: "ID:" });
+    if (id === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    const fields = await promptFields([
+      { name: "UserName", message: "UserName:" }
+    ]);
+    if (fields === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    console.log(await apiPut(`/api/exception-users/${id}`, fields));
+  }
+
+  if (action === "DELETE") {
+    const id = await promptField({ name: "id", message: "ID:" });
+    if (id === CANCEL) {
+      console.log("Canceled.");
+      return;
+    }
+    await apiDelete(`/api/exception-users/${id}`);
+    console.log("Deleted");
+  }
+};

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ import { handleGroupModuleLimit } from './actions/groupModuleLimit.js';
 import { handleUserGroup } from './actions/userGroup.js';
 import { handleLimits } from './actions/limit.js';
 import { handleSchedule } from './actions/schedule.js';
+import { handleExceptionUser } from './actions/exceptionUser.js';
 import { configure } from './config.js';
 
 const resources = [
@@ -12,6 +13,7 @@ const resources = [
   { name: 'User Group', value: 'user-group' },
   { name: 'Limits', value: 'limits' },
   { name: 'Schedule', value: 'schedule' },
+  { name: 'Exception User', value: 'exception-user' },
   { name: 'Configure', value: 'configure' },
   new inquirer.Separator(),
   { name: 'Exit', value: 'exit' }
@@ -22,6 +24,7 @@ const handlers = {
   'user-group': handleUserGroup,
   'limits': handleLimits,
   'schedule': handleSchedule,
+  'exception-user': handleExceptionUser,
   'configure': configure
 };
 


### PR DESCRIPTION
## Summary
- add CLI actions for managing exception users (list, get by id, create, update, delete)
- expose exception users resource in main CLI menu

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891ed9e8d888320ab0b663042bb2693