### PR TITLE
Fix menu scrolling by displaying all options

### DIFF
--- a/actions/exceptionUser.js
+++ b/actions/exceptionUser.js
@@ -4,19 +4,21 @@ import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
 import { promptFields, promptField, CANCEL } from "../prompt.js";
 
 export const handleExceptionUser = async () => {
+  const choices = [
+    { name: `${chalk.green("GET")} all`, value: "GET all" },
+    { name: `${chalk.green("GET")} by id`, value: "GET by id" },
+    { name: chalk.hex("#ff8800ff")("POST"), value: "POST" },
+    { name: chalk.yellow("PUT"), value: "PUT" },
+    { name: chalk.red("DELETE"), value: "DELETE" },
+    new inquirer.Separator(),
+    { name: "Back", value: "back" }
+  ];
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
     message: "Action:",
-    choices: [
-      { name: `${chalk.green("GET")} all`, value: "GET all" },
-      { name: `${chalk.green("GET")} by id`, value: "GET by id" },
-      { name: chalk.hex("#ff8800ff")("POST"), value: "POST" },
-      { name: chalk.yellow("PUT"), value: "PUT" },
-      { name: chalk.red("DELETE"), value: "DELETE" },
-      new inquirer.Separator(),
-      { name: "Back", value: "back" }
-    ]
+    choices,
+    pageSize: choices.length,
   });
 
   if (action === "back") {

--- a/actions/groupModuleLimit.js
+++ b/actions/groupModuleLimit.js
@@ -4,19 +4,21 @@ import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
 import { promptFields, promptField, CANCEL } from "../prompt.js";
 
 export const handleGroupModuleLimit = async () => {
+  const choices = [
+    { name: `${chalk.green("GET")} all`, value: "GET all" },
+    { name: `${chalk.green("GET")} by id`, value: "GET by id" },
+    { name: chalk.hex("#ff8800ff")("POST"), value: "POST" },
+    { name: chalk.yellow("PUT"), value: "PUT" },
+    { name: chalk.red("DELETE"), value: "DELETE" },
+    new inquirer.Separator(),
+    { name: "Back", value: "back" },
+  ];
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
     message: "Action:",
-    choices: [
-      { name: `${chalk.green("GET")} all`, value: "GET all" },
-      { name: `${chalk.green("GET")} by id`, value: "GET by id" },
-      { name: chalk.hex("#ff8800ff")("POST"), value: "POST" },
-      { name: chalk.yellow("PUT"), value: "PUT" },
-      { name: chalk.red("DELETE"), value: "DELETE" },
-      new inquirer.Separator(),
-      { name: "Back", value: "back" },
-    ],
+    choices,
+    pageSize: choices.length,
   });
 
   if (action === "back") {

--- a/actions/limit.js
+++ b/actions/limit.js
@@ -4,20 +4,22 @@ import { apiGet, apiPost } from "../api.js";
 import { promptField, CANCEL } from "../prompt.js";
 
 export const handleLimits = async () => {
+  const choices = [
+    { name: `${chalk.green("GET")} check/{pc}`, value: "GET check/{pc}" },
+    { name: `${chalk.green("GET")} users`, value: "GET users" },
+    {
+      name: chalk.hex("#ff8800ff")("POST stop session"),
+      value: "POST stop session",
+    },
+    new inquirer.Separator(),
+    { name: "Back", value: "back" },
+  ];
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
     message: "Action:",
-    choices: [
-      { name: `${chalk.green("GET")} check/{pc}`, value: "GET check/{pc}" },
-      { name: `${chalk.green("GET")} users`, value: "GET users" },
-      {
-        name: chalk.hex("#ff8800ff")("POST stop session"),
-        value: "POST stop session",
-      },
-      new inquirer.Separator(),
-      { name: "Back", value: "back" },
-    ],
+    choices,
+    pageSize: choices.length,
   });
 
   if (action === "back") {

--- a/actions/schedule.js
+++ b/actions/schedule.js
@@ -4,15 +4,17 @@ import { apiGet } from "../api.js";
 import { promptField, CANCEL } from "../prompt.js";
 
 export const handleSchedule = async () => {
+  const choices = [
+    { name: `${chalk.green("GET")}` + " by user", value: "GET by user" },
+    new inquirer.Separator(),
+    { name: "Back", value: "back" },
+  ];
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
     message: "Action:",
-    choices: [
-      { name: `${chalk.green("GET")}` + " by user", value: "GET by user" },
-      new inquirer.Separator(),
-      { name: "Back", value: "back" },
-    ],
+    choices,
+    pageSize: choices.length,
   });
 
   if (action === "back") {

--- a/actions/userGroup.js
+++ b/actions/userGroup.js
@@ -4,19 +4,21 @@ import { apiGet, apiPost, apiPut, apiDelete } from "../api.js";
 import { promptFields, promptField, CANCEL } from "../prompt.js";
 
 export const handleUserGroup = async () => {
+  const choices = [
+    { name: `${chalk.green('GET')} all`, value: "GET all" },
+    { name: `${chalk.green('GET')} by UserName`, value: "GET by UserName" },
+    { name: chalk.hex("#ff8800ff")('POST'), value: "POST" },
+    { name: chalk.yellow('PUT'), value: "PUT" },
+    { name: chalk.red('DELETE'), value: "DELETE" },
+    new inquirer.Separator(),
+    { name: 'Back', value: 'back' }
+  ];
   const { action } = await inquirer.prompt({
     type: "list",
     name: "action",
     message: "Action:",
-    choices: [
-      { name: `${chalk.green('GET')} all`, value: "GET all" },
-      { name: `${chalk.green('GET')} by UserName`, value: "GET by UserName" },
-      { name: chalk.hex("#ff8800ff")('POST'), value: "POST" },
-      { name: chalk.yellow('PUT'), value: "PUT" },
-      { name: chalk.red('DELETE'), value: "DELETE" },
-      new inquirer.Separator(),
-      { name: 'Back', value: 'back' }
-    ],
+    choices,
+    pageSize: choices.length,
   });
 
   if (action === 'back') {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ const main = async () => {
       type: 'list',
       name: 'resource',
       message: 'Select resource:',
-      choices: resources
+      choices: resources,
+      pageSize: resources.length
     });
 
     if (resource === 'exit') {


### PR DESCRIPTION
## Summary
- ensure all resource menus show the full list of choices
- apply pageSize configuration across action prompts to stop cycling

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check index.js actions/groupModuleLimit.js actions/userGroup.js actions/limit.js actions/schedule.js actions/exceptionUser.js`


------
https://chatgpt.com/codex/tasks/task_e_6892fafc61588320b07e28c3053765b8