### PR TITLE
feat: add help information for CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,26 @@ const handlers = {
   'configure': configure
 };
 
+const helpText = `Usage: slim-cli [options]
+
+Commands:
+  slim-cli config             Configure BASE_URL and X_API_KEY
+
+Routes:
+  group-module-limit    /api/group-module-limits
+  user-group            /api/user-groups
+  limits                /api/limits
+  schedule              /api/schedule/{userName}
+  exception-user        /api/exception-users
+
+Run without options to start interactive mode.`;
+
 const main = async () => {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    console.log(helpText);
+    return;
+  }
+
   if (process.argv[2] === 'config') {
     await configure();
     return;


### PR DESCRIPTION
## Summary
- show configuration and routes when using `--help`

## Testing
- `npm test` (fails: Error: no test specified)
- `node index.js --help`


------
https://chatgpt.com/codex/tasks/task_e_6893128f4b788320931925e47ea939cb